### PR TITLE
Refactor: Consolidate speed display logic in GenericStatisticsViewHolder

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
+++ b/src/main/java/de/dennisguse/opentracks/viewmodels/GenericStatisticsViewHolder.java
@@ -147,21 +147,22 @@ public abstract class GenericStatisticsViewHolder extends StatisticViewHolder<St
             getBinding().statsDescriptionMain.setText(getContext().getString(R.string.stats_average_speed));
         }
     }
+    private void configureSpeedDisplay(UnitSystem unitSystem, RecordingData data, boolean reportSpeed, int descriptionResId) {
+        SpeedFormatter speedFormatter = SpeedFormatter.Builder()
+                .setUnit(unitSystem)
+                .setReportSpeedOrPace(reportSpeed)
+                .build(getContext());
 
+        Pair<String, String> valueAndUnit = speedFormatter.getSpeedParts(data.getTrackStatistics().getMaxSpeed());
+
+        getBinding().statsValue.setText(valueAndUnit.first);
+        getBinding().statsUnit.setText(valueAndUnit.second);
+        getBinding().statsDescriptionMain.setText(getContext().getString(descriptionResId));
+    }
     public static class MaxSpeed extends GenericStatisticsViewHolder {
-
         @Override
         public void onChanged(UnitSystem unitSystem, RecordingData data) {
-            SpeedFormatter speedFormatterSpeed = SpeedFormatter.Builder()
-                    .setUnit(unitSystem)
-                    .setReportSpeedOrPace(true)
-                    .build(getContext());
-
-            Pair<String, String> valueAndUnit = speedFormatterSpeed.getSpeedParts(data.getTrackStatistics().getMaxSpeed());
-
-            getBinding().statsValue.setText(valueAndUnit.first);
-            getBinding().statsUnit.setText(valueAndUnit.second);
-            getBinding().statsDescriptionMain.setText(getContext().getString(R.string.stats_max_speed));
+            configureSpeedDisplay(unitSystem, data, true, R.string.stats_max_speed);
         }
     }
 
@@ -200,19 +201,9 @@ public abstract class GenericStatisticsViewHolder extends StatisticViewHolder<St
     }
 
     public static class FastestPace extends GenericStatisticsViewHolder {
-
         @Override
         public void onChanged(UnitSystem unitSystem, RecordingData data) {
-            SpeedFormatter speedFormatterSpeed = SpeedFormatter.Builder()
-                    .setUnit(unitSystem)
-                    .setReportSpeedOrPace(false)
-                    .build(getContext());
-
-            Pair<String, String> valueAndUnit = speedFormatterSpeed.getSpeedParts(data.getTrackStatistics().getMaxSpeed());
-
-            getBinding().statsValue.setText(valueAndUnit.first);
-            getBinding().statsUnit.setText(valueAndUnit.second);
-            getBinding().statsDescriptionMain.setText(getContext().getString(R.string.stats_fastest_pace));
+            configureSpeedDisplay(unitSystem, data, false, R.string.stats_fastest_pace);
         }
     }
 


### PR DESCRIPTION
Extracted duplicate logic for configuring and displaying speed into a private helper method configureSpeedDisplay. Updated MaxSpeed and FastestPace classes to use the helper method, passing appropriate parameters for reporting speed or pace.

# Thanks for your contribution.

## PLEASE REMOVE
To support us in providing a nice (and fast) open-source experience:
1. Verify that the tests are passing
2. Check that the code is properly formatted (using AndroidStudio's autoformatter)
3. Provide write access to the [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
4. If the PR is not ready for review, please submit it as a [draft](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
## PLEASE REMOVE

**Describe the pull request**
A clear and concise description of what the pull request changes/adds.

**Link to the the issue**
(If available): The link to the issue that this pull request solves.

**License agreement**
By opening this pull request, you are providing your contribution under the _Apache License 2.0_ (see [LICENSE.md](LICENSE.md)).

**Note: new dependencies/libraries**
Please refrain from introducing new libraries without consulting the team.
